### PR TITLE
feat(sdk.go): added WriteMetadata method

### DIFF
--- a/sdk.go
+++ b/sdk.go
@@ -212,6 +212,11 @@ func (k *KratixSDK) WriteOutput(relPath string, content []byte) error {
 	return k.write(k.outputDir, relPath, content)
 }
 
+// WriteMetadata writes content to the named file under the metadata directory.
+func (k *KratixSDK) WriteMetadata(relPath string, content []byte) error {
+	return k.write(k.metadataDir, relPath, content)
+}
+
 // WriteStatus writes the provided Status to status.yaml.
 func (k *KratixSDK) WriteStatus(s Status) error {
 	sts, ok := s.(*StatusImpl)

--- a/sdk_test.go
+++ b/sdk_test.go
@@ -146,6 +146,13 @@ var _ = Describe("E2E Tests", func() {
 					Expect(string(content)).To(Equal("output"))
 				})
 
+				By("writing to the metadata directory, creating any nested directories", func() {
+					err := sdk.WriteMetadata("foo/bar/metadata.yaml", []byte("metadata"))
+					Expect(err).ToNot(HaveOccurred())
+					content := readFileContent(metadataDir, "foo/bar/metadata.yaml")
+					Expect(string(content)).To(Equal("metadata"))
+				})
+
 				By("writing to the destination selectors yaml", func() {
 					err := sdk.WriteDestinationSelectors([]kratix.DestinationSelector{{
 						Directory:   "foo/bar",


### PR DESCRIPTION
### Changes

* added `WriteMetadata` method to `kratixSDK` (similar to `WriteOutputs`), enabling easier data sharing between containers of the same pipeline (ref: https://docs.kratix.io/main/reference/workflows#passing-data-between-containers)